### PR TITLE
Add velocity_controllers to scout_control/package.xml

### DIFF
--- a/scout/scout_control/package.xml
+++ b/scout/scout_control/package.xml
@@ -49,6 +49,7 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>velocity_controllers</build_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Scout simulation requires `ros-yourdistro-velocity-controllers`. Tested on ROS1 Noetic (not tested on melodic).